### PR TITLE
Bristol 872 Wavemeter device

### DIFF
--- a/BristolWavemeter/STBstatus.ui
+++ b/BristolWavemeter/STBstatus.ui
@@ -1,0 +1,423 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>307</width>
+    <height>218</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout_2">
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QLabel" name="byte_label">
+       <property name="font">
+        <font>
+         <pointsize>10</pointsize>
+         <weight>75</weight>
+         <bold>true</bold>
+         <underline>true</underline>
+        </font>
+       </property>
+       <property name="text">
+        <string>STATUS BYTE</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_3">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeType">
+        <enum>QSizePolicy::Fixed</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="clear_button">
+       <property name="toolTip">
+        <string>Clear</string>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="icon">
+        <iconset resource="../../Anaconda2/envs/labscript/Lib/site-packages/qtutils/icons/icons.qrc">
+         <normaloff>:/qtutils/fugue/arrow-circle.png</normaloff>:/qtutils/fugue/arrow-circle.png</iconset>
+       </property>
+       <property name="checkable">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <item>
+      <spacer name="horizontalSpacer_4">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <layout class="QVBoxLayout" name="verticalLayout">
+       <item>
+        <widget class="Line" name="line">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <layout class="QGridLayout" name="gridLayout">
+         <item row="0" column="0" alignment="Qt::AlignHCenter">
+          <widget class="QLabel" name="status_label_7">
+           <property name="font">
+            <font>
+             <weight>75</weight>
+             <bold>true</bold>
+             <underline>true</underline>
+            </font>
+           </property>
+           <property name="mouseTracking">
+            <bool>false</bool>
+           </property>
+           <property name="text">
+            <string>Bit 7</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1" alignment="Qt::AlignHCenter">
+          <widget class="QLabel" name="status_label_6">
+           <property name="font">
+            <font>
+             <weight>75</weight>
+             <bold>true</bold>
+             <underline>true</underline>
+            </font>
+           </property>
+           <property name="mouseTracking">
+            <bool>false</bool>
+           </property>
+           <property name="text">
+            <string>Bit 6</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="2" alignment="Qt::AlignHCenter">
+          <widget class="QLabel" name="status_label_5">
+           <property name="font">
+            <font>
+             <weight>75</weight>
+             <bold>true</bold>
+             <underline>true</underline>
+            </font>
+           </property>
+           <property name="mouseTracking">
+            <bool>false</bool>
+           </property>
+           <property name="text">
+            <string>Bit 5</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="3" alignment="Qt::AlignHCenter">
+          <widget class="QLabel" name="status_label_4">
+           <property name="font">
+            <font>
+             <weight>75</weight>
+             <bold>true</bold>
+             <underline>true</underline>
+            </font>
+           </property>
+           <property name="mouseTracking">
+            <bool>false</bool>
+           </property>
+           <property name="text">
+            <string>Bit 4</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0" alignment="Qt::AlignHCenter">
+          <widget class="QLabel" name="status_7">
+           <property name="mouseTracking">
+            <bool>false</bool>
+           </property>
+           <property name="text">
+            <string>????</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1" alignment="Qt::AlignHCenter">
+          <widget class="QLabel" name="status_6">
+           <property name="mouseTracking">
+            <bool>false</bool>
+           </property>
+           <property name="text">
+            <string>????</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="2" alignment="Qt::AlignHCenter">
+          <widget class="QLabel" name="status_5">
+           <property name="mouseTracking">
+            <bool>false</bool>
+           </property>
+           <property name="text">
+            <string>????</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="3" alignment="Qt::AlignHCenter">
+          <widget class="QLabel" name="status_4">
+           <property name="mouseTracking">
+            <bool>false</bool>
+           </property>
+           <property name="text">
+            <string>????</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0" alignment="Qt::AlignHCenter">
+          <widget class="QLabel" name="status_label_3">
+           <property name="font">
+            <font>
+             <weight>75</weight>
+             <bold>true</bold>
+             <underline>true</underline>
+            </font>
+           </property>
+           <property name="mouseTracking">
+            <bool>false</bool>
+           </property>
+           <property name="text">
+            <string>Bit 3</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1" alignment="Qt::AlignHCenter">
+          <widget class="QLabel" name="status_label_2">
+           <property name="font">
+            <font>
+             <weight>75</weight>
+             <bold>true</bold>
+             <underline>true</underline>
+            </font>
+           </property>
+           <property name="mouseTracking">
+            <bool>false</bool>
+           </property>
+           <property name="text">
+            <string>Bit 2</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="2" alignment="Qt::AlignHCenter">
+          <widget class="QLabel" name="status_label_1">
+           <property name="font">
+            <font>
+             <weight>75</weight>
+             <bold>true</bold>
+             <underline>true</underline>
+            </font>
+           </property>
+           <property name="mouseTracking">
+            <bool>false</bool>
+           </property>
+           <property name="text">
+            <string>Bit 1</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="3" alignment="Qt::AlignHCenter">
+          <widget class="QLabel" name="status_label_0">
+           <property name="font">
+            <font>
+             <weight>75</weight>
+             <bold>true</bold>
+             <underline>true</underline>
+            </font>
+           </property>
+           <property name="mouseTracking">
+            <bool>false</bool>
+           </property>
+           <property name="text">
+            <string>Bit 0</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="0" alignment="Qt::AlignHCenter">
+          <widget class="QLabel" name="status_3">
+           <property name="mouseTracking">
+            <bool>false</bool>
+           </property>
+           <property name="text">
+            <string>????</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="1" alignment="Qt::AlignHCenter">
+          <widget class="QLabel" name="status_2">
+           <property name="mouseTracking">
+            <bool>false</bool>
+           </property>
+           <property name="text">
+            <string>????</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="2" alignment="Qt::AlignHCenter">
+          <widget class="QLabel" name="status_1">
+           <property name="mouseTracking">
+            <bool>false</bool>
+           </property>
+           <property name="text">
+            <string>????</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="3" alignment="Qt::AlignHCenter">
+          <widget class="QLabel" name="status_0">
+           <property name="mouseTracking">
+            <bool>false</bool>
+           </property>
+           <property name="text">
+            <string>????</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_5">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>268</width>
+       <height>75</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <resources>
+  <include location="../../Anaconda2/envs/labscript/Lib/site-packages/qtutils/icons/icons.qrc"/>
+ </resources>
+ <connections/>
+</ui>

--- a/BristolWavemeter/__init__.py
+++ b/BristolWavemeter/__init__.py
@@ -1,0 +1,17 @@
+#####################################################################
+#                                                                   #
+# /naqslab_devices/BristolWavemeter/__init__.py                     #
+#                                                                   #
+# Copyright 2025, Jason Pruitt                                      #
+#                                                                   #
+# This file is part of the naqslab devices extension to the         #
+# labscript_suite. It is licensed under the Simplified BSD License. #
+#                                                                   #
+#                                                                   #
+#####################################################################
+
+from labscript_devices import deprecated_import_alias
+
+
+# # For backwards compatibility with old experiment scripts:
+# BristolWavemeter = deprecated_import_alias("naqslab_devices.BristolWavemeter.labscript_device.BristolWavemeter")

--- a/BristolWavemeter/blacs_tab.py
+++ b/BristolWavemeter/blacs_tab.py
@@ -101,10 +101,10 @@ class BristolWavemeterTab(DeviceTab):
         # call VISATab.initialise to create BristolWavemeter widget
         DeviceTab.initialise_GUI(self)
 
-        # Set the capabilities of this device
-        self.supports_remote_value_check(True)
+        # # Set the capabilities of this device
+        self.supports_remote_value_check(False)
         self.supports_smart_programming(True) # TODO is this necessary?
-        # self.statemachine_timeout_add(5000, self.status_monitor)   
+        # # self.statemachine_timeout_add(5000, self.status_monitor)   
                 
         # add entries to worker kwargs
         # this allows inheritors to initialize with added entries for their own workers
@@ -122,35 +122,35 @@ class BristolWavemeterTab(DeviceTab):
         self.primary_worker = "main_worker"       
 
 
-    # # TODO - I think we said to move away from this
-    # # This function gets the status,
-    # # and updates the front panel widgets!
-    @define_state(MODE_MANUAL|MODE_BUFFERED|MODE_TRANSITION_TO_BUFFERED|MODE_TRANSITION_TO_MANUAL,True)  
-    def status_monitor(self):
-        # When called with a queue, this function writes to the queue
-        # when the pulseblaster is waiting. This indicates the end of
-        # an experimental run.
-        self.status = yield(self.queue_work(self._primary_worker,'check_status'))
+    # # # TODO - I think we said to move away from this
+    # # # This function gets the status,
+    # # # and updates the front panel widgets!
+    # @define_state(MODE_MANUAL|MODE_BUFFERED|MODE_TRANSITION_TO_BUFFERED|MODE_TRANSITION_TO_MANUAL,True)  
+    # def status_monitor(self):
+    #     # When called with a queue, this function writes to the queue
+    #     # when the pulseblaster is waiting. This indicates the end of
+    #     # an experimental run.
+    #     self.status = yield(self.queue_work(self._primary_worker,'check_status'))
 
-        for key in self.status_bits:
-            if self.status[key]:
-                icon = QtGui.QIcon(':/qtutils/fugue/tick')
-            else:
-                icon = QtGui.QIcon(':/qtutils/fugue/cross')
-            pixmap = icon.pixmap(QtCore.QSize(16,16))
-            self.bit_values_widgets[key].setPixmap(pixmap)
+    #     for key in self.status_bits:
+    #         if self.status[key]:
+    #             icon = QtGui.QIcon(':/qtutils/fugue/tick')
+    #         else:
+    #             icon = QtGui.QIcon(':/qtutils/fugue/cross')
+    #         pixmap = icon.pixmap(QtCore.QSize(16,16))
+    #         self.bit_values_widgets[key].setPixmap(pixmap)
         
-    @define_state(MODE_MANUAL|MODE_BUFFERED|MODE_TRANSITION_TO_BUFFERED|MODE_TRANSITION_TO_MANUAL,True,True)
-    def wavelength_changed(self,widget=None):
-        value = self.status_ui.sens_comboBox.currentIndex()
-        new_value = yield(self.queue_work(self._primary_worker,'set_wavelength',value))
+    # @define_state(MODE_MANUAL|MODE_BUFFERED|MODE_TRANSITION_TO_BUFFERED|MODE_TRANSITION_TO_MANUAL,True,True)
+    # def wavelength_changed(self,widget=None):
+    #     value = self.status_ui.sens_comboBox.currentIndex()
+    #     new_value = yield(self.queue_work(self._primary_worker,'set_wavelength',value))
         
-        # only update if value is different
-        if new_value != value:
-            # block signals for update
-            self.status_ui.tau_comboBox.blockSignals(True)
-            self.status_ui.tau_comboBox.setCurrentIndex(new_value)
-            self.status_ui.tau_comboBox.blockSignals(False)
+    #     # only update if value is different
+    #     if new_value != value:
+    #         # block signals for update
+    #         self.status_ui.tau_comboBox.blockSignals(True)
+    #         self.status_ui.tau_comboBox.setCurrentIndex(new_value)
+    #         self.status_ui.tau_comboBox.blockSignals(False)
 
     @define_state(MODE_MANUAL|MODE_BUFFERED|MODE_TRANSITION_TO_BUFFERED|MODE_TRANSITION_TO_MANUAL,True,True)
     def send_clear(self,widget=None):

--- a/BristolWavemeter/blacs_tab.py
+++ b/BristolWavemeter/blacs_tab.py
@@ -1,0 +1,158 @@
+#####################################################################
+#                                                                   #
+# /naqslab_devices/BristolWavemeter/blacs_tab.py                    #
+#                                                                   #
+# Copyright 2025, Jason Pruitt                                      #
+#                                                                   #
+# This file is part of the naqslab devices extension to the         #
+# labscript_suite. It is licensed under the Simplified BSD License. #
+#                                                                   #
+#                                                                   #
+#####################################################################
+from blacs.device_base_class import DeviceTab
+
+from blacs.tab_base_classes import define_state
+from blacs.tab_base_classes import MODE_MANUAL, MODE_TRANSITION_TO_BUFFERED, MODE_TRANSITION_TO_MANUAL, MODE_BUFFERED 
+from qtutils import UiLoader
+import os
+
+# Imports for handling icons in STBstatus.ui
+from qtutils.qt import QtCore
+from qtutils.qt import QtGui
+
+class BristolWavemeterTab(DeviceTab):
+    status_widget = 'STBstatus.ui'
+    STBui_path = os.path.join(os.path.dirname(os.path.realpath(__file__)),status_widget)
+
+    # # Capabilities
+    # def initialize_GUI(self):
+    #     self.base_units =    {'wavelength':'nm-vac'}
+    #     self.base_min =      {'wavelength':0.0}
+    #     self.base_max =      {'wavelength':3000.0}
+    #     self.base_step =     {'wavelength':1}
+    #     self.base_decimals = {'wavelength':1}
+                
+    # Event Status Register (ESR) Labels
+    status_byte_labels = {
+                        'bit 7':'Power On', 
+                        'bit 6':'unused',
+                        'bit 5':'Command Error',
+                        'bit 4':'Execution Error',
+                        'bit 3':'Device Dependent Error',
+                        'bit 2':'Query Error',
+                        'bit 1':'unused',
+                        'bit 0':'OPC'
+                        }
+    # instrument status bytes
+    status_byte_labels = {
+                        'bit 7':'unused', 
+                        'bit 6':'unused',
+                        'bit 5':'Bit exists in questionable register',
+                        'bit 4':'unused',
+                        'bit 3':'Errors in error queue',
+                        'bit 2':'Bit exists in event status register',
+                        'bit 1':'unused',
+                        'bit 0':'unused'
+                        }
+
+    def __init__(self,*args,**kwargs):
+        # set the worker
+        self.device_worker_class = 'naqslab_devices.BristolWavemeter.blacs_worker.BristolWavemeterWorker'
+        DeviceTab.__init__(self,*args,**kwargs)
+    
+    # stole this from VISA gui logic
+    def initialise_GUI(self):
+        self.status_ui = UiLoader().load(self.STBui_path)
+        self.get_tab_layout().addWidget(self.status_ui)
+        
+        # generate the dictionaries
+        self.status_bits = ['bit 0', 'bit 1', 'bit 2', 'bit 3', 'bit 4', 'bit 5', 'bit 6', 'bit 7']
+        self.bit_labels_widgets = {}
+        self.bit_values_widgets = {}
+        self.status = {}
+        for bit in self.status_bits:
+            self.status[bit] = False
+            self.bit_values_widgets[bit] = getattr(self.status_ui, 'status_{0:s}'.format(bit.split()[1]))
+            self.bit_labels_widgets[bit] = getattr(self.status_ui, 'status_label_{0:s}'.format(bit.split()[1]))
+        
+        # Dynamically update status bits with correct names           
+        for key in self.status_bits:
+            self.bit_labels_widgets[key].setText(self.status_byte_labels[key])
+        self.status_ui.clear_button.clicked.connect(self.send_clear)
+
+        # Store the VISA name to be used
+        self.address = str(self.settings['connection_table'].find_by_name(self.settings["device_name"]).BLACS_connection)
+        
+        # use AO widgets to mimick functionality
+        analog_properties = {
+            'frequency':{
+                'base_unit':'GHz',
+                'min':8e5,
+                'max':1.7647059e5,
+                'step':1e-3,
+                'decimals':6
+                },
+            }
+      
+        self.create_analog_outputs(analog_properties)
+        ao_widgets = self.create_analog_widgets(analog_properties)
+        self.auto_place_widgets(('Frequency',ao_widgets))
+        
+        # call VISATab.initialise to create BristolWavemeter widget
+        DeviceTab.initialise_GUI(self)
+
+        # Set the capabilities of this device
+        self.supports_remote_value_check(True)
+        self.supports_smart_programming(True) # TODO is this necessary?
+        # self.statemachine_timeout_add(5000, self.status_monitor)   
+                
+        # add entries to worker kwargs
+        # this allows inheritors to initialize with added entries for their own workers
+        if not hasattr(self,'worker_init_kwargs'):
+            self.worker_init_kwargs = {}
+            
+        self.worker_init_kwargs['address'] = self.address
+        self.worker_init_kwargs['device_name'] = self.device_name
+
+        # Create and set the primary worker
+        self.create_worker("main_worker",
+                            self.device_worker_class,
+                            {'address':self.address,
+                            })
+        self.primary_worker = "main_worker"       
+
+
+    # # TODO - I think we said to move away from this
+    # # This function gets the status,
+    # # and updates the front panel widgets!
+    @define_state(MODE_MANUAL|MODE_BUFFERED|MODE_TRANSITION_TO_BUFFERED|MODE_TRANSITION_TO_MANUAL,True)  
+    def status_monitor(self):
+        # When called with a queue, this function writes to the queue
+        # when the pulseblaster is waiting. This indicates the end of
+        # an experimental run.
+        self.status = yield(self.queue_work(self._primary_worker,'check_status'))
+
+        for key in self.status_bits:
+            if self.status[key]:
+                icon = QtGui.QIcon(':/qtutils/fugue/tick')
+            else:
+                icon = QtGui.QIcon(':/qtutils/fugue/cross')
+            pixmap = icon.pixmap(QtCore.QSize(16,16))
+            self.bit_values_widgets[key].setPixmap(pixmap)
+        
+    @define_state(MODE_MANUAL|MODE_BUFFERED|MODE_TRANSITION_TO_BUFFERED|MODE_TRANSITION_TO_MANUAL,True,True)
+    def wavelength_changed(self,widget=None):
+        value = self.status_ui.sens_comboBox.currentIndex()
+        new_value = yield(self.queue_work(self._primary_worker,'set_wavelength',value))
+        
+        # only update if value is different
+        if new_value != value:
+            # block signals for update
+            self.status_ui.tau_comboBox.blockSignals(True)
+            self.status_ui.tau_comboBox.setCurrentIndex(new_value)
+            self.status_ui.tau_comboBox.blockSignals(False)
+
+    @define_state(MODE_MANUAL|MODE_BUFFERED|MODE_TRANSITION_TO_BUFFERED|MODE_TRANSITION_TO_MANUAL,True,True)
+    def send_clear(self,widget=None):
+        value = self.status_ui.clear_button.isChecked()
+        yield(self.queue_work(self._primary_worker,'clear',value))

--- a/BristolWavemeter/blacs_tab.py
+++ b/BristolWavemeter/blacs_tab.py
@@ -24,14 +24,6 @@ class BristolWavemeterTab(DeviceTab):
     status_widget = 'STBstatus.ui'
     STBui_path = os.path.join(os.path.dirname(os.path.realpath(__file__)),status_widget)
 
-    # # Capabilities
-    # def initialize_GUI(self):
-    #     self.base_units =    {'wavelength':'nm-vac'}
-    #     self.base_min =      {'wavelength':0.0}
-    #     self.base_max =      {'wavelength':3000.0}
-    #     self.base_step =     {'wavelength':1}
-    #     self.base_decimals = {'wavelength':1}
-                
     # Event Status Register (ESR) Labels
     status_byte_labels = {
                         'bit 7':'Power On', 
@@ -128,7 +120,6 @@ class BristolWavemeterTab(DeviceTab):
                             })
         self.primary_worker = "main_worker"       
 
-
     # # TODO - I think we said to move away from this
     # # This function gets the status,
     # # and updates the front panel widgets!
@@ -146,18 +137,6 @@ class BristolWavemeterTab(DeviceTab):
                 icon = QtGui.QIcon(':/qtutils/fugue/cross')
             pixmap = icon.pixmap(QtCore.QSize(16,16))
             self.bit_values_widgets[key].setPixmap(pixmap)
-        
-    # @define_state(MODE_MANUAL|MODE_BUFFERED|MODE_TRANSITION_TO_BUFFERED|MODE_TRANSITION_TO_MANUAL,True,True)
-    # def wavelength_changed(self,widget=None):
-    #     value = self.status_ui.sens_comboBox.currentIndex()
-    #     new_value = yield(self.queue_work(self._primary_worker,'set_wavelength',value))
-        
-    #     # only update if value is different
-    #     if new_value != value:
-    #         # block signals for update
-    #         self.status_ui.tau_comboBox.blockSignals(True)
-    #         self.status_ui.tau_comboBox.setCurrentIndex(new_value)
-    #         self.status_ui.tau_comboBox.blockSignals(False)
 
     @define_state(MODE_MANUAL|MODE_BUFFERED|MODE_TRANSITION_TO_BUFFERED|MODE_TRANSITION_TO_MANUAL,True,True)
     def send_clear(self,widget=None):

--- a/BristolWavemeter/blacs_tab.py
+++ b/BristolWavemeter/blacs_tab.py
@@ -24,18 +24,19 @@ class BristolWavemeterTab(DeviceTab):
     status_widget = 'STBstatus.ui'
     STBui_path = os.path.join(os.path.dirname(os.path.realpath(__file__)),status_widget)
 
-    # Event Status Register (ESR) Labels
-    status_byte_labels = {
-                        'bit 7':'Power On', 
-                        'bit 6':'unused',
-                        'bit 5':'Command Error',
-                        'bit 4':'Execution Error',
-                        'bit 3':'Device Dependent Error',
-                        'bit 2':'Query Error',
-                        'bit 1':'unused',
-                        'bit 0':'OPC'
-                        }
-    # instrument status bytes
+    # # Event Status Enable Register (ESE) Labels
+    # status_byte_labels = {
+    #                     'bit 7':'Power On', 
+    #                     'bit 6':'unused',
+    #                     'bit 5':'Command Error',
+    #                     'bit 4':'Execution Error',
+    #                     'bit 3':'Device Dependent Error',
+    #                     'bit 2':'Query Error',
+    #                     'bit 1':'unused',
+    #                     'bit 0':'OPC'
+    #                     }
+    
+    # *STB? labels
     status_byte_labels = {
                         'bit 7':'unused', 
                         'bit 6':'unused',
@@ -77,17 +78,11 @@ class BristolWavemeterTab(DeviceTab):
         
         # use AO widgets to mimick functionality
         analog_properties = {
-            # 'frequency':{
-            #     'base_unit':'Hz',
-            #     'min':2.14285714e13, # freq -> 14,000 nm
-            #     'max':8.57142857e14, # freq -> 350 nm
-            #     'step':1e-3,
-            #     'decimals':6
-            #     },
+
             'wavelength':{
                 'base_unit':'nm',
-                'min':14000, # freq -> 14,000 nm
-                'max':350, # freq -> 350 nm
+                'min':14000, # nm
+                'max':350, # nm
                 'step':1e-6,
                 'decimals':6
                 },
@@ -95,7 +90,7 @@ class BristolWavemeterTab(DeviceTab):
       
         self.create_analog_outputs(analog_properties)
         ao_widgets = self.create_analog_widgets(analog_properties)
-        self.auto_place_widgets(('wavelength',ao_widgets))
+        self.auto_place_widgets(('wavelength', ao_widgets))
         
         # call VISATab.initialise to create BristolWavemeter widget
         DeviceTab.initialise_GUI(self)
@@ -103,7 +98,7 @@ class BristolWavemeterTab(DeviceTab):
         # # Set the capabilities of this device
         self.supports_remote_value_check(False)
         self.supports_smart_programming(True)
-        # # self.statemachine_timeout_add(5000, self.status_monitor)   
+        self.statemachine_timeout_add(5000, self.status_monitor)   
                 
         # add entries to worker kwargs
         # this allows inheritors to initialize with added entries for their own workers
@@ -120,7 +115,6 @@ class BristolWavemeterTab(DeviceTab):
                             })
         self.primary_worker = "main_worker"       
 
-    # # TODO - I think we said to move away from this
     # # This function gets the status,
     # # and updates the front panel widgets!
     @define_state(MODE_MANUAL|MODE_BUFFERED|MODE_TRANSITION_TO_BUFFERED|MODE_TRANSITION_TO_MANUAL,True)  

--- a/BristolWavemeter/blacs_tab.py
+++ b/BristolWavemeter/blacs_tab.py
@@ -85,25 +85,32 @@ class BristolWavemeterTab(DeviceTab):
         
         # use AO widgets to mimick functionality
         analog_properties = {
-            'frequency':{
-                'base_unit':'GHz',
-                'min':8e5,
-                'max':1.7647059e5,
-                'step':1e-3,
+            # 'frequency':{
+            #     'base_unit':'Hz',
+            #     'min':2.14285714e13, # freq -> 14,000 nm
+            #     'max':8.57142857e14, # freq -> 350 nm
+            #     'step':1e-3,
+            #     'decimals':6
+            #     },
+            'wavelength':{
+                'base_unit':'nm',
+                'min':14000, # freq -> 14,000 nm
+                'max':350, # freq -> 350 nm
+                'step':1e-6,
                 'decimals':6
                 },
             }
       
         self.create_analog_outputs(analog_properties)
         ao_widgets = self.create_analog_widgets(analog_properties)
-        self.auto_place_widgets(('Frequency',ao_widgets))
+        self.auto_place_widgets(('wavelength',ao_widgets))
         
         # call VISATab.initialise to create BristolWavemeter widget
         DeviceTab.initialise_GUI(self)
 
         # # Set the capabilities of this device
         self.supports_remote_value_check(False)
-        self.supports_smart_programming(True) # TODO is this necessary?
+        self.supports_smart_programming(True)
         # # self.statemachine_timeout_add(5000, self.status_monitor)   
                 
         # add entries to worker kwargs
@@ -122,23 +129,23 @@ class BristolWavemeterTab(DeviceTab):
         self.primary_worker = "main_worker"       
 
 
-    # # # TODO - I think we said to move away from this
-    # # # This function gets the status,
-    # # # and updates the front panel widgets!
-    # @define_state(MODE_MANUAL|MODE_BUFFERED|MODE_TRANSITION_TO_BUFFERED|MODE_TRANSITION_TO_MANUAL,True)  
-    # def status_monitor(self):
-    #     # When called with a queue, this function writes to the queue
-    #     # when the pulseblaster is waiting. This indicates the end of
-    #     # an experimental run.
-    #     self.status = yield(self.queue_work(self._primary_worker,'check_status'))
+    # # TODO - I think we said to move away from this
+    # # This function gets the status,
+    # # and updates the front panel widgets!
+    @define_state(MODE_MANUAL|MODE_BUFFERED|MODE_TRANSITION_TO_BUFFERED|MODE_TRANSITION_TO_MANUAL,True)  
+    def status_monitor(self):
+        # When called with a queue, this function writes to the queue
+        # when the pulseblaster is waiting. This indicates the end of
+        # an experimental run.
+        self.status = yield(self.queue_work(self._primary_worker,'check_status'))
 
-    #     for key in self.status_bits:
-    #         if self.status[key]:
-    #             icon = QtGui.QIcon(':/qtutils/fugue/tick')
-    #         else:
-    #             icon = QtGui.QIcon(':/qtutils/fugue/cross')
-    #         pixmap = icon.pixmap(QtCore.QSize(16,16))
-    #         self.bit_values_widgets[key].setPixmap(pixmap)
+        for key in self.status_bits:
+            if self.status[key]:
+                icon = QtGui.QIcon(':/qtutils/fugue/tick')
+            else:
+                icon = QtGui.QIcon(':/qtutils/fugue/cross')
+            pixmap = icon.pixmap(QtCore.QSize(16,16))
+            self.bit_values_widgets[key].setPixmap(pixmap)
         
     # @define_state(MODE_MANUAL|MODE_BUFFERED|MODE_TRANSITION_TO_BUFFERED|MODE_TRANSITION_TO_MANUAL,True,True)
     # def wavelength_changed(self,widget=None):

--- a/BristolWavemeter/blacs_worker.py
+++ b/BristolWavemeter/blacs_worker.py
@@ -197,8 +197,8 @@ class BristolWavemeterWorker(Worker):
     def check_remote_values(self):
         results = {}
         all_vals = self.intf.get_all_meas()
-        print(f"check_remote_values: all_vals: {all_vals}")
-        # print(f"vs front panel: {front_panel_values}")
+        self.logger.info(f"check_remote_values: all_vals: {all_vals}")
+        # self.logger.info(f"vs front panel: {front_panel_values}")
         all_vals_list = all_vals.split(',')
 
         try:
@@ -211,7 +211,7 @@ class BristolWavemeterWorker(Worker):
     
     def program_manual(self, front_panel_values):
         '''Performs manual updates from BLACS front panel.'''
-        print(f'Front panel values: {front_panel_values}')
+        self.logger.info(f'Front panel values: {front_panel_values}')
 
         results = {}
         wavelength = front_panel_values['wavelength']
@@ -219,8 +219,7 @@ class BristolWavemeterWorker(Worker):
 
         self.intf.set_PID_setpoint(float(wavelength))
 
-        # return self.check_remote_values() # this works but overrides front panel with remote
-        return results # not sure about this
+        return results
 
     def transition_to_buffered(self,device_name,h5file,initial_values,fresh):
         self.final_values = initial_values
@@ -235,7 +234,6 @@ class BristolWavemeterWorker(Worker):
             if len(pid_instructions) == 0:
                 return {}
             
-            # print(pid_instructions)
             setpoint = pid_instructions['setpoint'][0]
             self.logger.info(f'Read setpoint: {setpoint}')
 
@@ -243,7 +241,7 @@ class BristolWavemeterWorker(Worker):
 
         self.logger.info('Setpoint successfully set, exiting transition to buffered')
         
-        return {}
+        return self.final_values
     
     def clear(self, value):
         self.intf.send_msg_no_read(b'*CLS\r\n')

--- a/BristolWavemeter/blacs_worker.py
+++ b/BristolWavemeter/blacs_worker.py
@@ -1,0 +1,193 @@
+#####################################################################
+#                                                                   #
+# /naqslab_devices/BristolWavemeter/blacs_worker.py                 #
+#                                                                   #
+# Copyright 2025, Jason Pruitt                                      #
+#                                                                   #
+# This file is part of the naqslab devices extension to the         #
+# labscript_suite. It is licensed under the Simplified BSD License. #
+#                                                                   #
+#                                                                   #
+#####################################################################
+import numpy as np
+# from naqslab_devices.VISA.blacs_worker import VISAWorker
+from labscript import LabscriptError
+from blacs.tab_base_classes import Worker
+
+import labscript_utils.h5_lock, h5py
+import labscript_utils.properties
+
+# # import sensitivity and tau settings from labscript device
+# from naqslab_devices.BristolWavemeter.labscript_device import sens, tau
+
+from struct import unpack
+
+class BristolWavemeterInterface(object):
+    def __init__(self, ip_address):
+        global telnetlib; import telnetlib
+
+        try:
+            self.timeout = 3
+            self.conn = telnetlib.Telnet(ip_address)
+            self.conn.set_debuglevel(0)
+            self.skipOpeningMessage(0.5) # is this not necessary?
+
+        except Exception as e:
+            raise e
+        
+        identity = self.get_identity()
+        print(f'IDN Response: {identity}')
+        all_meas = self.get_all_meas()
+        print(f'ALL Response: {all_meas}')
+        # current_status = self.check_status()
+        # print(f'Current status is: {current_status}')
+
+        # current_wavelength = self.get_wavelength()
+        # print(f'Current wavelength is: {current_wavelength}')
+
+        # PID_capable = self.check_if_PID()
+        # print(f'PID: {PID_capable}')
+
+    def send_msg(self, msg):
+        read_msg = msg + b'\r\n'
+        self.conn.write(read_msg)
+        skip_count = 0
+        out = b''
+        while(True):
+            out = self.conn.read_some()
+            if out != b'' and out != b'1':
+                # print(out)
+                return out
+
+    def get_identity(self):
+        msg = b'*IDN?\r\n'
+        out = self.send_msg(msg)
+        out.replace(b'\n\r',b'')
+        return(out.decode('ascii'))
+            
+    def get_wavelength(self):
+        msg = b':READ:WAV?\r\n'
+        out = self.send_msg(msg)
+        out.replace(b'\n\r',b'')
+        return float(out.decode('ascii'))
+    
+    def get_all_meas(self):
+        msg = b':READ:ALL?\r\n'
+        out = self.send_msg(msg)
+        out.replace(b'\n\r',b'')
+        # return(out.decode('ascii'))
+        return(out.decode('ascii'))
+        
+    # def readWN(self):
+    #     msg = b':READ:WNUM?\r\n'
+    #     out = self.send_msg(msg)
+    #     out.replace(b'\n\r',b'')
+    #     return float(out.decode('ascii'))
+
+    def convert_register(self,register):
+        """Converts returned register value to dict of bools
+        """
+        results = {}
+        #get the status and convert to binary, and take off the '0b' header:
+        status = bin(register)[2:]
+        # if the status is less than 8 bits long, pad the start with zeros!
+        while len(status)<8:
+            status = '0'+status
+        # reverse the status string so bit 0 is first indexed
+        status = status[::-1]
+        # fill the status byte dictionary
+        for i in range(0,8):
+            results['bit '+str(i)] = bool(int(status[i]))
+        
+        return results
+
+    def check_if_PID(self):
+        msg = b':SENSe:PID:FUNCtion?'
+        out = self.send_msg(msg)
+        out.replace(b'\n\r', b'')
+        return out.decode('ascii')
+    
+    def set_PID_setpoint(self, value):
+        msg = b':SENSe:PID:SPO %d', value
+        out = self.send_msg(msg)
+        out.replace(b'\n\r', b'')
+        return out.decode('ascii') 
+
+    def check_status(self):
+        msg = b'*STB?\r\n'
+        out = self.send_msg(msg)
+        out.replace(b'\n\r',b'')
+        out = out.decode('ascii')
+        mask = 122
+        error_code = out & mask
+        return error_code
+        
+    #     if error_code:
+    #         # error exists, but nothing to report beyond register value
+    #         print('{:s} has ESR = {:d}'.format(self.name, error_code))
+        
+    #     return self.convert_register(esr)
+
+    ##Skip the opening telnet connection message.
+    #@param wait_sec - time taken to read input message x3
+    def skipOpeningMessage(self, wait_sec):
+        print('{}'.format("testing connection"))
+        skip_count = 0
+        while(True):
+            #out = self.conn.rawq_getchar()
+            out = self.conn.read_until(b'\n\n',wait_sec)
+            if out == b'':
+                skip_count += 1
+            if skip_count > 2:
+                break
+
+class BristolWavemeterWorker(Worker):
+    # setup_string = '*ESE'
+    
+    def init(self):
+        Worker.init(self)
+        self.intf = BristolWavemeterInterface(self.ip_address)
+    
+    def check_status(self):
+        status = self.intf.check_status()
+        return(status)
+    
+    def check_remote_values(self):
+        results = {}
+        all_vals = self.intf.get_all_meas()
+        print(f"check_remote_values: all_vals: {all_vals}")
+        all_vals_list = all_vals.split(',')
+
+        wavelength = all_vals_list[2].strip()
+        try:
+            frequency = 3e8 / float(wavelength)
+            results['frequency'] = frequency
+        except ZeroDivisionError:
+            results['frequency'] = 0.0
+
+        return results
+    
+    # def remote_update_front_panel(self, front_panel_values):
+    #     current_remote = self.check_remote_values()
+    #     try:
+    #         self.program_manual(current_remote['wavelength'])
+    #     except Exception as e:
+    #         raise e
+    
+    def program_manual(self,front_panel_values):
+        '''Performs manual updates from BLACS front panel.'''
+        print(f'Front panel values: {front_panel_values}')
+
+        results = {}
+        frequency = front_panel_values['frequency']
+        results['frequency'] = float(frequency)
+                
+        # return self.check_remote_values() # this works but overrides front panel with remote
+        return results # not sure about this
+
+    def transition_to_buffered(self,device_name,h5file,initial_values,fresh):
+        # call parent method to do basic preamble
+        Worker.transition_to_buffered(self,device_name,h5file,initial_values,fresh)
+        pass
+
+

--- a/BristolWavemeter/blacs_worker.py
+++ b/BristolWavemeter/blacs_worker.py
@@ -107,12 +107,10 @@ class BristolWavemeterInterface(object):
         return out.decode('ascii')
     
     def set_PID_setpoint(self, value):
-        print('Entering setpoint func')
         if value >= 350 and value <= 14_000:
-            msg = b':SENSe:PID:SPO %d' % value
+            msg = b':SENSe:PID:SPO %f' % value
             out = self.send_msg_no_read(msg)
             # out.replace(b'\n\r', b'')
-            print('Exiting setpoint func')
             # return out.decode('ascii') 
         else:
             # Requested frequencies need to be within {21428, 857143 }
@@ -219,8 +217,10 @@ class BristolWavemeterWorker(Worker):
         wavelength = front_panel_values['wavelength']
         results['wavelength'] = float(wavelength)
 
-        return self.check_remote_values() # this works but overrides front panel with remote
-        # return results # not sure about this
+        self.intf.set_PID_setpoint(float(wavelength))
+
+        # return self.check_remote_values() # this works but overrides front panel with remote
+        return results # not sure about this
 
     def transition_to_buffered(self,device_name,h5file,initial_values,fresh):
         self.final_values = initial_values

--- a/BristolWavemeter/labscript_device.py
+++ b/BristolWavemeter/labscript_device.py
@@ -1,0 +1,96 @@
+#####################################################################
+#                                                                   #
+# /naqslab_devices/BristolWavemeter/labscript_device.py             #
+#                                                                   #
+# Copyright 2025, Jason Pruitt                                      #
+#                                                                   #
+# This file is part of the naqslab devices extension to the         #
+# labscript_suite. It is licensed under the Simplified BSD License. #
+#                                                                   #
+#                                                                   #
+#####################################################################
+import numpy as np
+
+# from naqslab_devices.VISA.labscript_device import VISA
+from labscript import Device, StaticAnalogOut, config, LabscriptError, set_passed_properties
+
+__version__ = '0.1.0'
+__author__ = ['Json-To-String']
+
+
+# class _BristolWavemeterBackendAO(StaticAnalogOut):
+#     def __init__()
+#     pass
+class BristolWavemeter(Device):
+    description = 'BristolWavemeter'
+    allowed_children = [StaticAnalogOut]
+    
+    # frequency = None
+
+    @set_passed_properties(
+        property_names={
+            'connection_table_properties': [
+                'ip_address',
+            ]
+        }
+    )
+    def __init__(
+            self, name, ip_address,
+            default_value = 0.0,
+            **kwargs):
+        # does not have a parent device
+        
+        Device.__init__(self, name, None, ip_address, **kwargs)
+        self.name = name
+        self.BLACS_connection = ip_address ## double check this
+
+        # Prawn{Blaster, DO} devices do something like this
+        self._analog_output_backend = StaticAnalogOut(
+            name + "Internal",
+            parent_device = self,
+            connection = "Internal",
+            limits=None, # TODO
+            unit_conversion_class=None,
+            unit_conversion_parameters=None,
+            default_value=default_value,
+        )
+
+        # Device.add_device
+        self.add_device(self._analog_output_backend) 
+        # self._analog_output_backend.frequency = 8e5 # lowest value -> 375 nm
+
+    # TODO: how to set this up so it updates the front panel
+    # def set_wavelength(self, frequency, units='hz'):
+    def set_frequency(self, frequency):
+
+        # convert the requested frequency to nm since PID setpoint expressed in nm
+        freq_to_wavelength = 3e8 / frequency
+        print('setting frequency to %d\n' % int(freq_to_wavelength))
+        ## call looks like: StaticAnalogQuantity.constant(value, units) ##
+        
+        self._analog_output_backend.constant(freq_to_wavelength)
+
+    def generate_code(self, hdf5_file):
+        '''Generates the transition to buffered code in the h5 file.
+        If parameter is not specified in shot, NaN and -1 values are set
+        to tell worker not to change the value when programming.'''
+
+        backend_devices = {}
+        for output in self.child_devices:
+            index = output.connection
+            backend_devices[index] = output
+            # print(output.static_value)
+
+        if not backend_devices:
+            return
+
+        dtypes = np.dtype({
+            'names':['frequency'],
+            'formats':[np.float64]
+            })
+        out_table = np.zeros(1, dtype=dtypes)
+        for i, dev in backend_devices.items():
+            out_table['frequency'][:] = dev.static_value 
+
+        grp = hdf5_file.create_group('/devices/'+self.name)
+        grp.create_dataset('PID_instructions',compression=config.compression,data=out_table) 

--- a/BristolWavemeter/labscript_device.py
+++ b/BristolWavemeter/labscript_device.py
@@ -86,7 +86,10 @@ class BristolWavemeterConversion(UnitConversion):
         return THz
     
 class BristolWavemeter(Device):
-    """ The main device class for the Bristol Wavemeter, currently only tested with 872 model."""
+    """
+    The main device class for the Bristol Wavemeter, 
+    currently only tested with 872 model.
+    """
 
     description = 'BristolWavemeter'
     allowed_children = [StaticAnalogOut]

--- a/BristolWavemeter/labscript_device.py
+++ b/BristolWavemeter/labscript_device.py
@@ -13,19 +13,123 @@ import numpy as np
 
 # from naqslab_devices.VISA.labscript_device import VISA
 from labscript import Device, StaticAnalogOut, config, LabscriptError, set_passed_properties
+# from labscript_utils.unitconversions import UnitConversionBase
+from labscript_utils.unitconversions.UnitConversionBase import UnitConversion
 
 __version__ = '0.1.0'
 __author__ = ['Json-To-String']
 
+# class FreqConversion(UnitConversion):
+#     """
+#     A Generic frequency conversion class that covers standard SI prefixes from a base of Hz.
+#     """
 
-# class _BristolWavemeterBackendAO(StaticAnalogOut):
-#     def __init__()
-#     pass
+#     base_unit = 'Hz' # must be defined here and match default hardware unit in BLACS tab
+
+#     def __init__(self, calibration_parameters = None):
+#         self.parameters = calibration_parameters
+#         if hasattr(self, 'derived_units'):
+#             self.derived_units += ['kHz', 'MHz', 'GHz', 'THz']
+#         else:
+#             self.derived_units = ['kHz', 'MHz', 'GHz', 'THz']
+#         UnitConversion.__init__(self,self.parameters)
+    
+#     def kHz_to_base(self,kHz):
+#         Hz = kHz*1e3
+#         return Hz
+
+#     def kHz_from_base(self,Hz):
+#         kHz = Hz*1e-3
+#         return kHz
+
+#     def MHz_to_base(self,MHz):
+#         Hz = MHz*1e6
+#         return Hz
+
+#     def MHz_from_base(self,Hz):
+#         MHz = Hz*1e-6
+#         return MHz
+
+#     def GHz_to_base(self,GHz):
+#         Hz = GHz*1e9
+#         return Hz
+
+#     def GHz_from_base(self,Hz):
+#         GHz = Hz*1e-9
+#         return GHz
+    
+#     def THz_to_base(self,THz):
+#         Hz = THz*1e12
+#         return Hz
+
+#     def THz_from_base(self,Hz):
+#         THz = Hz*1e-12
+#         return THz
+
+class BristolWavemeterConversion(UnitConversion):
+    # This must be defined outside of init, and must match the default hardware unit specified within the BLACS tab
+    base_unit = 'nm'
+
+    def __init__(self, calibration_parameters = None):
+        self.parameters = calibration_parameters
+        if hasattr(self, 'derived_units'):
+            self.derived_units += ['Hz', 'kHz', 'MHz', 'GHz', 'THz']
+        else:
+            self.derived_units = ['Hz', 'kHz', 'MHz', 'GHz', 'THz']
+        UnitConversion.__init__(self, self.parameters)
+    
+    # Could reuse this for DRY
+    def Hz_to_base(self, Hz):
+        nm = 3e8 / Hz
+        return nm
+    
+    def Hz_from_base(self, nm):
+        Hz = 3e8 / nm
+        return Hz
+    
+    def kHz_to_base(self, kHz):
+        Hz = kHz * 1e3
+        nm = 3e8 / Hz
+        return nm
+
+    def kHz_from_base(self, nm):
+        Hz = 3e8 / nm
+        kHz = Hz * 1e-3
+        return kHz
+
+    def MHz_to_base(self, MHz):
+        Hz = MHz * 1e6
+        nm = 3e8 / Hz
+        return nm
+
+    def MHz_from_base(self, nm):
+        Hz = 3e8 / nm
+        MHz = Hz * 1e-6
+        return MHz
+
+    def GHz_to_base(self, GHz):
+        Hz = GHz * 1e9
+        nm = 3e8 / Hz
+        return nm
+
+    def GHz_from_base(self, nm):
+        Hz = 3e8 / nm
+        GHz = Hz * 1e-9
+        return GHz
+    
+    def THz_to_base(self, THz):
+        Hz = THz * 1e12
+        nm = 3e8 / Hz
+        return nm
+
+    def THz_from_base(self, nm):
+        Hz = 3e8 / nm
+        THz = Hz * 1e-12
+        return THz
+    
 class BristolWavemeter(Device):
     description = 'BristolWavemeter'
     allowed_children = [StaticAnalogOut]
-    
-    # frequency = None
 
     @set_passed_properties(
         property_names={
@@ -43,6 +147,7 @@ class BristolWavemeter(Device):
         Device.__init__(self, name, None, ip_address, **kwargs)
         self.name = name
         self.BLACS_connection = ip_address ## double check this
+        self.setpoint_type = None
 
         # Prawn{Blaster, DO} devices do something like this
         self._analog_output_backend = StaticAnalogOut(
@@ -50,27 +155,42 @@ class BristolWavemeter(Device):
             parent_device = self,
             connection = "Internal",
             limits=None, # TODO
-            unit_conversion_class=None,
-            unit_conversion_parameters=None,
+            unit_conversion_class=BristolWavemeterConversion,
+            unit_conversion_parameters={'magnitudes': ['M', 'G', 'T']},
             default_value=default_value,
         )
 
-        # Device.add_device
-        self.add_device(self._analog_output_backend) 
-        # self._analog_output_backend.frequency = 8e5 # lowest value -> 375 nm
+        ## Is it better to overload the add_device method here?
+        # Device.add_device(self, device)
+        self.add_device(self._analog_output_backend)
 
-    # def set_wavelength(self, frequency, units='hz'):
-    def set_frequency(self, frequency):
+    def get_default_unit_conversion_classes(self, device):
+        """Child devices call this during their __init__ (with themselves
+        as the argument) to check if there are certain unit calibration
+        classes that they should apply to their outputs, if the user has
+        not otherwise specified a calibration class"""
 
-        # convert the requested frequency to nm since PID setpoint expressed in nm
-        freq_to_wavelength = 3e8 / frequency
+        return BristolWavemeterConversion
 
-        # setpoints are ints
-        freq_to_wavelength = int(freq_to_wavelength)
-        print('Frequency to wavelength: %d\n' % freq_to_wavelength)
-        ## call looks like: StaticAnalogQuantity.constant(value, units) ##
+    # def set_setpoint(self, type: str, value: float, units = None):
+    def set_setpoint(self, value: float, units = None):
         
-        self._analog_output_backend.constant(freq_to_wavelength)
+        ## -- some unit conversions here -- ##
+        self._analog_output_backend.constant(value, units)
+
+    # def set_frequency(self, frequency, units = None):
+    #     ##
+    #     # convert the requested frequency to nm since PID setpoint expressed in nm
+    #     freq_to_wavelength = 3e8 / frequency
+
+    #     freq_to_wavelength = freq_to_wavelength
+    #     print('Frequency to wavelength: %d\n' % freq_to_wavelength)
+    #     ## call looks like: StaticAnalogQuantity.constant(value, units) ##
+        
+    #     self._analog_output_backend.constant(freq_to_wavelength, units)
+    #     ##
+    #     print(f'Got frequency: {frequency}')
+    #     self._analog_output_backend.constant(frequency, units)
 
     def generate_code(self, hdf5_file):
         '''Generates the transition to buffered code in the h5 file.
@@ -85,10 +205,10 @@ class BristolWavemeter(Device):
         if not backend_devices:
             return
 
+        columns = ['setpoint']
         dtypes = np.dtype({
-            'names':['setpoint'],
-            # 'formats':[np.float64]
-            'formats':['<f8']
+            'names': columns,
+            'formats': ['<f8']
             })
         
         out_table = np.zeros(1, dtype=dtypes)
@@ -97,3 +217,4 @@ class BristolWavemeter(Device):
 
         grp = hdf5_file.create_group('/devices/' + self.name)
         grp.create_dataset('PID_instructions', compression=config.compression, data=out_table) 
+

--- a/BristolWavemeter/register_classes.py
+++ b/BristolWavemeter/register_classes.py
@@ -1,0 +1,17 @@
+#####################################################################
+#                                                                   #
+# /naqslab_devices/BristolWavemeter/register_classes.py             #
+#                                                                   #
+# Copyright 2025, Jason Pruitt                                      #
+#                                                                   #
+# This file is part of the naqslab devices extension to the         #
+# labscript_suite. It is licensed under the Simplified BSD License. #
+#                                                                   #
+#                                                                   #
+#####################################################################
+import labscript_devices
+
+labscript_devices.register_classes(
+    'BristolWavemeter',
+    BLACS_tab='naqslab_devices.BristolWavemeter.blacs_tab.BristolWavemeterTab',
+    runviewer_parser='')


### PR DESCRIPTION
Initial infrastructure for the Bristol 872 Wavemeter

Currently, the usage goes like: 

Script sent to runmanager:
```python 
from labscript import *
from naqslab_devices.BristolWavemeter.labscript_device import BristolWavemeter

wavemeter = BristolWavemeter(name='wavemeter', ip_address='10.199.199.1')

start()
# PID setpoint will be converted to nm if not specified as such.
# User can specify values in {'Hz', 'MHz', 'GHz', 'THz'}
wavemeter.set_setpoint(value=3.84e5 * 10**9, units='GHz')

# Or if desired in nm omit units.
wavemeter.set_setpoint(value=480) 
stop(1)
```

Shot in blacs will set the setpoint to requested value.

I need to add some helpful comments and docstrings, and the front panel doesn't perfectly represent the value the PID is actually set to. But all the backend should be correct.