### PR TITLE
Lock-In Amplifier EnumOutput Option

### DIFF
--- a/SR865/blacs_tab.py
+++ b/SR865/blacs_tab.py
@@ -30,29 +30,63 @@ class SR865Tab(VISATab):
         # set the worker
         self.device_worker_class = 'naqslab_devices.SR865.blacs_worker.SR865Worker'
         VISATab.__init__(self,*args,**kwargs)
-    
+
     def initialise_GUI(self):
-        
-        # use AO widgets to mimick functionality
-        ao_prop = {'tau':{'base_unit':'s',
-                          'min':1e-6,
-                          'max':30e3,
-                          'step':1,
-                          'decimals':6},
-                    'sens':{'base_unit':'V',
-                            'min':1e-9,
-                            'max':1,
-                            'step':1e-3,
-                            'decimals':9},
-                    'phase':{'base_unit':'deg',
-                             'min':-180,
-                             'max':180,
-                             'step':1,
-                             'decimals':6}}
-                            
-        self.create_analog_outputs(ao_prop)
-        ao_widgets = self.create_analog_widgets(ao_prop)
-        self.auto_place_widgets(('Settings',ao_widgets))
+        self.connection_table_properties = (
+            self.settings["connection_table"].find_by_name(self.device_name).properties
+        )
+        use_enums_option = self.connection_table_properties['use_enums_option']
+
+        if use_enums_option == True:
+            eo_prop = {
+                'sens':{
+                    'options':[1,500e-3,200e-3,100e-3,50e-3,20e-3,10e-3,5e-3,2e-3,1e-3,
+                    500e-6,200e-6,100e-6,50e-6,20e-6,10e-6,5e-6,2e-6,1e-6,
+                    500e-9,200e-9,100e-9,50e-9,20e-9,10e-9,5e-9,2e-9,1e-9], # uses default 0-indexing
+                    'return_index':True, # widget will return integer index instead of string value when queried
+                },
+                'tau':{
+                    'options':[1e-6,3e-6,10e-6,30e-6,100e-6,300e-6,
+                        1e-3,3e-3,10e-3,30e-3,100e-3,300e-3,
+                        1,3,10,30,100,300,1e3,3e3,10e3,30e3],
+                    'return_index':True,
+                },
+            }
+            self.create_enum_outputs(eo_prop)
+            eo_widgets = self.auto_create_enum_widgets()
+
+            self.auto_place_widgets(('Settings', eo_widgets))
+            ao_prop = {
+                        'phase':{'base_unit':'deg',
+                                'min':-180,
+                                'max':180,
+                                'step':1,
+                                'decimals':6}}
+            self.create_analog_outputs(ao_prop)
+            ao_widgets = self.create_analog_widgets(ao_prop)
+            self.auto_place_widgets(('Settings',ao_widgets))
+
+        else:
+            # use AO widgets to mimick functionality
+            ao_prop = {'tau':{'base_unit':'s',
+                            'min':1e-6,
+                            'max':30e3,
+                            'step':1,
+                            'decimals':6},
+                        'sens':{'base_unit':'V',
+                                'min':1e-9,
+                                'max':1,
+                                'step':1e-3,
+                                'decimals':9},
+                        'phase':{'base_unit':'deg',
+                                'min':-180,
+                                'max':180,
+                                'step':1,
+                                'decimals':6}}
+                                
+            self.create_analog_outputs(ao_prop)
+            ao_widgets = self.create_analog_widgets(ao_prop)
+            self.auto_place_widgets(('Settings',ao_widgets))
         
         # call VISATab.initialise to create SR865 widget
         VISATab.initialise_GUI(self)

--- a/SR865/blacs_worker.py
+++ b/SR865/blacs_worker.py
@@ -48,7 +48,6 @@ class SR865Worker(VISAWorker):
     def init(self):
         # Call the VISA init to initialise the VISA connection
         VISAWorker.init(self)
-        
         # initial configure of the instrument
         self.connection.write('*ESE 122;*CLS;')
     
@@ -69,11 +68,17 @@ class SR865Worker(VISAWorker):
     def program_manual(self,front_panel_values):
         '''Performans manual updates from BLACS front panel.
         Tau and Sensitivity settings are coerced to nearest allowed value'''
-        tau_i = self.coerce_tau(front_panel_values['tau'])
-        sens_i = self.coerce_sens(front_panel_values['sens'])
-        phase = front_panel_values['phase']
-        
-        self.connection.write(self.program_string.format(tau_i,sens_i,phase))
+
+        if self.use_enums_option == False:
+            tau_i = self.coerce_tau(front_panel_values['tau'])
+            sens_i = self.coerce_sens(front_panel_values['sens'])
+            phase = front_panel_values['phase']
+            self.connection.write(self.program_string.format(tau_i,sens_i,phase))
+        else:
+            tau = front_panel_values['tau']
+            sens = front_panel_values['sens']
+            phase = front_panel_values['phase']
+            self.connection.write(self.program_string.format(tau,sens,phase))
                 
         return self.check_remote_values()        
 

--- a/SR865/labscript_device.py
+++ b/SR865/labscript_device.py
@@ -34,12 +34,18 @@ class SR865(VISA):
     sens = None
     phase = None
 
-    @set_passed_properties()
-    def __init__(self, name, VISA_name):
+    @set_passed_properties(        
+        property_names={
+            'connection_table_properties': [
+                'use_enums_option',
+            ]
+        })    
+    def __init__(self, name, VISA_name, use_enums_option=False):
         '''VISA_name can be full VISA connection string or NI-MAX alias'''
         # does not have a parent device
         VISA.__init__(self,name,None,VISA_name)
-        
+        self.use_enums_option = use_enums_option
+
     def set_tau(self, tau_constant):
         '''Set the time constant in seconds.
         Uses numpy digitize to translate to int values.


### PR DESCRIPTION
Adding the ability to choose enum outputs for sens and tau for the SR865A using blacs PR [109](https://github.com/labscript-suite/blacs/pull/109) (Enum widget support). Will otherwise default to using the regular analog outputs unless specified like so:

```python
from naqslab_devices.SR865.labscript_device import SR865

SR865(name='LockIn', VISA_name='SR865', use_enums_option=True)
```

Currently only tested on my bench but not in an active experiment.